### PR TITLE
Use `id`, not `sustainicertid` for gold standard project urls

### DIFF
--- a/offsets_db_data/gld.py
+++ b/offsets_db_data/gld.py
@@ -70,12 +70,10 @@ def process_gld_credits(
 @pf.register_dataframe_method
 def add_gld_project_url(df: pd.DataFrame) -> pd.DataFrame:
     """Add url for gold standard projects
-    
+
     gs project ids are different from the id used in gold standard urls.
     """
-    df['project_url'] = 'https://registry.goldstandard.org/projects/details/' + df[
-        'id'
-    ].apply(str)
+    df['project_url'] = 'https://registry.goldstandard.org/projects/details/' + df['id'].apply(str)
     return df
 
 


### PR DESCRIPTION
project_ids are displayed and relate to the sustainicert id. the id in the url appears to be something else unreleated