### PR TITLE
Specify verra datetime format

### DIFF
--- a/offsets_db_data/common.py
+++ b/offsets_db_data/common.py
@@ -1,4 +1,5 @@
 import json
+import typing
 from collections import defaultdict
 
 import pandas as pd
@@ -60,11 +61,11 @@ def set_registry(df: pd.DataFrame, registry_name: str) -> pd.DataFrame:
 
 @pf.register_dataframe_method
 def convert_to_datetime(
-    df: pd.DataFrame, *, columns: list, date_format: str = 'mixed', utc: bool = True
+    df: pd.DataFrame, *, columns: list, utc: bool = True, **kwargs: typing.Any
 ) -> pd.DataFrame:
     for column in columns:
         if column in df.columns:
-            df[column] = pd.to_datetime(df[column], format=date_format, utc=utc)
+            df[column] = pd.to_datetime(df[column], utc=utc, **kwargs)
         else:
             raise KeyError(f"The column '{column}' is missing.")
     return df

--- a/offsets_db_data/vcs.py
+++ b/offsets_db_data/vcs.py
@@ -92,7 +92,7 @@ def process_vcs_credits(
         )
         .clean_and_convert_numeric_columns(columns=['Total Vintage Quantity', 'Quantity Issued'])
         .set_vcs_vintage_year(date_column='Vintage End')
-        .convert_to_datetime(columns=['transaction_date'], format='%d-%m-%Y')
+        .convert_to_datetime(columns=['transaction_date'], dayfirst=True)
     )
 
     issuances = data.calculate_vcs_issuances()
@@ -213,7 +213,7 @@ def process_vcs_projects(
         .add_retired_and_issued_totals(credits=credits)
         .add_first_issuance_and_retirement_dates(credits=credits)
         .add_missing_columns(columns=project_schema.columns.keys())
-        .convert_to_datetime(columns=['listed_at'])
+        .convert_to_datetime(columns=['listed_at'], dayfirst=True)
         .validate(schema=project_schema)
     )
 


### PR DESCRIPTION
Verra reports all dates in the following format: %d-%m-%Y. Specify that date format to avoid parsing errors.

Closes #29 