### PR TITLE
Reclassify cookstove projects

### DIFF
--- a/offsets_db_data/configs/all-protocol-mapping.json
+++ b/offsets_db_data/configs/all-protocol-mapping.json
@@ -1801,7 +1801,7 @@
     ]
   },
   "gs-drinking-water": {
-    "category":  "energy-efficiency",
+    "category": "energy-efficiency",
     "sub-category": "drinking-water",
     "known-strings": [
       "GS Methodology for emission reductions from safe drinking water supply"


### PR DESCRIPTION
Many of the big protocols that allow cookstoves also allow other approaches. New classification represents that ambiguity.