### PR TITLE
Handle `ValueError` in date parsing to improve robustness of `set_vcs_vintage_year` function

### DIFF
--- a/offsets_db_data/vcs.py
+++ b/offsets_db_data/vcs.py
@@ -109,7 +109,10 @@ def set_vcs_vintage_year(df: pd.DataFrame, *, date_column: str) -> pd.DataFrame:
         DataFrame with a new 'vintage' column, containing the vintage year of each transaction.
     """
 
-    df[date_column] = pd.to_datetime(df[date_column], format='%d/%m/%Y', utc=True)
+    try:
+        df[date_column] = pd.to_datetime(df[date_column], format='%d/%m/%Y', utc=True)
+    except ValueError:
+        df[date_column] = pd.to_datetime(df[date_column], utc=True)
     df['vintage'] = df[date_column].dt.year
     return df
 


### PR DESCRIPTION

The most recent data from VCS contains data with a different format which breaks the ETL pipeline

```python
In [27]: url = "s3://carbonplan-scratch/offsets-db-test/raw/2024-11-21/verra/transactions.csv.gz"
In [29]: df = pd.read_csv(url)

In [30]: df['Vintage End']
Out[30]: 
0         2022-09-30
1         2021-12-31
2         2020-12-31
3         2021-12-31
4         2022-12-31
             ...    
263798    2007-10-20
263799    2006-12-31
263800    2007-12-31
263801    2007-12-31
263802    2007-12-31

In [30]: date_column = 'Vintage End'

In [31]: pd.to_datetime(df[date_column], format='%d/%m/%Y', utc=True)
```

```python
    466     """
--> 467     result, tz_out = array_strptime(arg, fmt, exact=exact, errors=errors, utc=utc)
    468     if tz_out is not None:
    469         unit = np.datetime_data(result.dtype)[0]

File strptime.pyx:501, in pandas._libs.tslibs.strptime.array_strptime()

File strptime.pyx:451, in pandas._libs.tslibs.strptime.array_strptime()

File strptime.pyx:583, in pandas._libs.tslibs.strptime._parse_with_format()

ValueError: time data "2022-09-30" doesn't match format "%d/%m/%Y", at position 0. You might want to try:
    - passing `format` if your strings have a consistent format;
    - passing `format='ISO8601'` if your strings are all ISO8601 but not necessarily in exactly the same format;
    - passing `format='mixed'`, and the format will be inferred for each element individually. You might want to use `dayfirst` alongside this.

```