### PR TITLE
Replace fastparquet with pyarrow for parquet file handling

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -23,8 +23,30 @@ env:
   AWS_DEFAULT_REGION: us-west-2
 
 jobs:
-  test:
+  unit-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Pixi
+        uses: prefix-dev/setup-pixi@v0.9.3
+        with:
+          cache: true
+          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+
+      - name: List packages
+        run: pixi list
+
+      - name: Run unit tests
+        run: pixi run test-cov
+
+  integration:
+    runs-on: ubuntu-latest
+    needs: unit-test
     timeout-minutes: 120
     defaults:
       run:
@@ -49,7 +71,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.3
         with:
           cache: true
-          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          cache-write: false
 
       - name: List packages
         run: pixi list
@@ -59,9 +81,6 @@ jobs:
 
       - name: Show CLI help
         run: pixi run offsets-db-data-orcli --help
-
-      - name: Run unit tests
-        run: pixi run test-cov
 
       - name: Run integration tests
         run: pixi run test-integration

--- a/offsets_db_data/catalog.yaml
+++ b/offsets_db_data/catalog.yaml
@@ -36,7 +36,7 @@ sources:
     args:
       urlpath: 's3://carbonplan-offsets-db/final/{{ date }}/credits-augmented.parquet'
       storage_options: { 'anon': True }
-      engine: 'fastparquet'
+      engine: 'pyarrow'
 
   projects:
     description: OffsetsDB processed and transformed data
@@ -49,7 +49,7 @@ sources:
     args:
       urlpath: 's3://carbonplan-offsets-db/final/{{ date }}/projects-augmented.parquet'
       storage_options: { 'anon': True }
-      engine: 'fastparquet'
+      engine: 'pyarrow'
 
   raw_projects:
     description: Raw projects data downloaded from the registries on a daily basis

--- a/offsets_db_data/pipeline_utils.py
+++ b/offsets_db_data/pipeline_utils.py
@@ -168,16 +168,12 @@ def to_parquet(
     registry_name : str, optional
             The name of the registry for logging purposes.
     """
-    credits.to_parquet(
-        output_paths['credits'], index=False, compression='gzip', engine='fastparquet'
-    )
+    credits.to_parquet(output_paths['credits'], index=False, compression='gzip', engine='pyarrow')
 
     prefix = f'{registry_name} ' if registry_name else ''
     print(f'Wrote {prefix} credits to {output_paths["credits"]}...')
 
-    projects.to_parquet(
-        output_paths['projects'], index=False, compression='gzip', engine='fastparquet'
-    )
+    projects.to_parquet(output_paths['projects'], index=False, compression='gzip', engine='pyarrow')
     print(f'Wrote {prefix} projects to {output_paths["projects"]}...')
 
 
@@ -223,12 +219,12 @@ def _create_data_zip_buffer(
         elif format_type == 'parquet':
             # Write Parquet files to temporary files
             with tempfile.NamedTemporaryFile(suffix='.parquet') as temp_credits:
-                credits.to_parquet(temp_credits.name, index=False, engine='fastparquet')
+                credits.to_parquet(temp_credits.name, index=False, engine='pyarrow')
                 temp_credits.seek(0)
                 zf.writestr('credits.parquet', temp_credits.read())
 
             with tempfile.NamedTemporaryFile(suffix='.parquet') as temp_projects:
-                projects.to_parquet(temp_projects.name, index=False, engine='fastparquet')
+                projects.to_parquet(temp_projects.name, index=False, engine='pyarrow')
                 temp_projects.seek(0)
                 zf.writestr('projects.parquet', temp_projects.read())
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -4255,12 +4255,12 @@ packages:
   requires_python: '>=3.11'
 - pypi: ./
   name: offsets-db-data
-  version: 2025.12.2.post12+g033b388c6.d20260414
-  sha256: 4a10d8d71e40739a2d7841f882cf7e609ea11fa9849af6824436469e5dbfa3d1
+  version: 2025.12.2.post13+g5dcc6e4b5
+  sha256: 47e6d8e38903c03273aec4951909a9ab2306d153ca5309e15601c6c200da2a26
   requires_dist:
   - country-converter==1.0.0
   - dask>=2025.2.0
-  - fastparquet>=2024.11
+  - pyarrow>=16.0
   - fsspec>=2025.2.0
   - intake-parquet>=0.3.0
   - intake<2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@
     dependencies = [
         "country_converter==1.0.0",
         "dask>=2025.2.0",
-        "fastparquet>=2024.11",
+        "pyarrow>=16.0",
         "fsspec>=2025.2.0",
         "intake-parquet>=0.3.0",
         "intake<2",


### PR DESCRIPTION
- pyarrow now handles everything fastparquet did, pandas depends on it anyway, so fastparquet has no reason to continue. 
- https://github.com/dask/fastparquet/pull/973