### PR TITLE
feat: Audit protocols script

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 permissions:
   id-token: write # This is required for requesting the JWT
-  contents: read # This is required for actions/checkout
+  contents: write # This is required for actions/checkout and committing the audit report
 
 env:
   AWS_DEFAULT_REGION: us-west-2
@@ -84,3 +84,47 @@ jobs:
 
       - name: Run integration tests
         run: pixi run test-integration
+
+  audit:
+    runs-on: ubuntu-latest
+    needs: integration
+    timeout-minutes: 15
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::631969445205:role/github-action-role
+          role-session-name: offsets-db-audit-role-session
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Setup Pixi
+        uses: prefix-dev/setup-pixi@v0.9.5
+        with:
+          cache: true
+          cache-write: false
+
+      - name: Resolve latest S3 data date
+        run: |
+          LATEST=$(aws s3 ls s3://carbonplan-offsets-db/raw/ | awk '{print $2}' | sort | tail -1 | tr -d '/')
+          if [[ -z "$LATEST" ]]; then
+            echo "ERROR: no dated prefixes found under s3://carbonplan-offsets-db/raw/"
+            exit 1
+          fi
+          echo "S3_DATA_DIR=s3://carbonplan-offsets-db/raw/$LATEST" >> "$GITHUB_ENV"
+
+      - name: Run mapping coverage audit
+        run: pixi run audit-protocols --data-dir "$S3_DATA_DIR" --output docs/unmapped-protocols.md | tee -a "$GITHUB_STEP_SUMMARY" || true
+
+      - name: Commit updated unmapped protocols report
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/unmapped-protocols.md
+          git diff --staged --quiet || git commit -m "chore: update unmapped protocols report [skip ci]"
+          git push

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ pixi run lint              # Run linting
 pixi run format            # Format code
 pixi run format-check      # Check formatting without modifying files
 pixi run docs-build        # Build documentation
+pixi run audit-protocols   # Audit protocol mapping coverage
 ```
 
 Activate an interactive shell with all dependencies:

--- a/docs/data-processing.md
+++ b/docs/data-processing.md
@@ -95,7 +95,7 @@ Across all registries included in OffsetsDB, we identified twenty-two unique way
 OffsetsDB addresses this problem by manually assigning every known protocol string to a common schema.
 Continuing with the AMS-III.D. example, we map all twenty-two "known strings" that describe the same protocol to a single, unified reference, `ams-iii-d`.
 We repeat this manual unification of dissimilar strings for all protocols across all registries.
-The results of the mapping are contained within [`offsets-db-data/configs/all-protocol-mapping.json`](https://github.com/carbonplan/offsets-db-data/blob/main/offsets_db_data/configs/all-protocol-mapping.json).
+The results of the mapping are contained within [`offsets-db-data/configs/all-protocol-mapping.json`](https://github.com/carbonplan/offsets-db-data/blob/main/offsets_db_data/configs/all-protocol-mapping.json). See [Unmapped Protocols](unmapped-protocols.md) for a report of protocol strings that have not yet been manually mapped.
 
 ## Project Type & Categorization
 
@@ -130,6 +130,16 @@ Project types are determined through a multi-step process:
 2. We apply manual overrides from curated data sources (via {py:obj}`offsets_db_data.projects.override_project_types`).
    Currently, the [Berkeley Carbon Trading Project](https://gspp.berkeley.edu/research-and-impact/centers/cepp/projects/berkeley-carbon-trading-project) data in [`offsets-db-data/configs/berkeley-project-types.json`](https://github.com/carbonplan/offsets-db-data/blob/main/offsets_db_data/configs/berkeley-project-types.json) serves as the authoritative source for project types.
    The project types from the Berkeley Carbon Trading Project's Voluntary Registry Offsets Database are licensed under a [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/) license.
+
+## Auditing Mapping Coverage
+
+When adding a new registry or updating protocol strings, check for unmapped protocol strings and unresolved project types by running:
+
+```bash
+pixi run audit-protocols
+```
+
+This scans `tests/data/` (or a directory specified via `--data-dir`) against the current mapping configs and prints a gap report covering both protocol mapping and project type assignment. The same check runs automatically in CI against the full dataset; `tests/data/` contains only a representative subset.
 
 ## Retirement User Harmonization
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ hidden:
 ---
 
 data-processing.md
+unmapped-protocols.md
 api.md
 glossary.md
 TERMS-OF-DATA-ACCESS.md

--- a/offsets_db_data/arb.py
+++ b/offsets_db_data/arb.py
@@ -5,15 +5,17 @@ import pandas_flavor as pf
 
 from offsets_db_data.common import convert_to_datetime  # noqa: F401
 from offsets_db_data.models import credit_without_id_schema
+from offsets_db_data.registry import ACR_PREFIX, ART_PREFIX, CAR_PREFIX, VCS_PREFIX
 
 
 def _get_registry(item):
     registry_map = {
-        'CAR': 'climate-action-reserve',
-        'ACR': 'american-carbon-registry',
-        'VCS': 'verra',
-        'ART': 'art-trees',
+        CAR_PREFIX: 'climate-action-reserve',
+        ACR_PREFIX: 'american-carbon-registry',
+        VCS_PREFIX: 'verra',
+        ART_PREFIX: 'art-trees',
     }
+
     prefix = item[:3]
     return registry_map.get(prefix)
 

--- a/offsets_db_data/cercarbono.py
+++ b/offsets_db_data/cercarbono.py
@@ -26,6 +26,7 @@ from offsets_db_data.projects import (
     harmonize_status_codes,  # noqa: F401
     map_protocol,  # noqa: F401
 )
+from offsets_db_data.registry import CCB_PREFIX
 
 
 @pf.register_dataframe_method
@@ -48,7 +49,7 @@ def add_cercarbono_project_url(df: pd.DataFrame) -> pd.DataFrame:
 
 
 @pf.register_dataframe_method
-def add_cercarbono_project_id(df: pd.DataFrame, prefix: str = 'CCB') -> pd.DataFrame:
+def add_cercarbono_project_id(df: pd.DataFrame, prefix: str = CCB_PREFIX) -> pd.DataFrame:
     """Add project ID column for Cercarbono credits dataframe.
 
     Parameters
@@ -75,7 +76,7 @@ def process_cercarbono_credits(
     *,
     download_type: str,
     registry_name: str = 'cercarbono',
-    prefix: str = 'CCB',
+    prefix: str = CCB_PREFIX,
     harmonize_beneficiary_info: bool = False,
 ) -> pd.DataFrame:
     """Process Cercarbono transactions dataframe to conform to offsets-db schema.

--- a/offsets_db_data/gld.py
+++ b/offsets_db_data/gld.py
@@ -12,6 +12,7 @@ from offsets_db_data.common import (
     load_registry_project_column_mapping,
     load_type_category_mapping,
 )
+from offsets_db_data.registry import GLD_PREFIX
 from offsets_db_data.credits import aggregate_issuance_transactions  # noqa: F401
 from offsets_db_data.credits import filter_and_merge_transactions  # noqa: F401
 from offsets_db_data.credits import merge_with_arb  # noqa: F401
@@ -77,7 +78,7 @@ def process_gld_credits(
     *,
     download_type: str,
     registry_name: str = 'gold-standard',
-    prefix: str = 'GLD',
+    prefix: str = GLD_PREFIX,
     arb: pd.DataFrame | None = None,
     harmonize_beneficiary_info: bool = False,
 ) -> pd.DataFrame:
@@ -184,7 +185,7 @@ def process_gld_projects(
     *,
     credits: pd.DataFrame,
     registry_name: str = 'gold-standard',
-    prefix: str = 'GLD',
+    prefix: str = GLD_PREFIX,
 ) -> pd.DataFrame:
     """
     Process Gold Standard projects data, including renaming, adding, and validating columns, harmonizing statuses,

--- a/offsets_db_data/isometric.py
+++ b/offsets_db_data/isometric.py
@@ -27,6 +27,7 @@ from offsets_db_data.projects import (
     harmonize_status_codes,  # noqa: F401
     map_protocol,  # noqa: F401
 )
+from offsets_db_data.registry import ISO_PREFIX
 
 
 @pf.register_dataframe_method
@@ -48,7 +49,7 @@ def add_isometric_project_url(df: pd.DataFrame) -> pd.DataFrame:
 
 
 @pf.register_dataframe_method
-def add_isometric_project_id(df: pd.DataFrame, prefix: str = 'ISO') -> pd.DataFrame:
+def add_isometric_project_id(df: pd.DataFrame, prefix: str = ISO_PREFIX) -> pd.DataFrame:
     """Add project ID column for Isometric credits dataframe.
 
     Parameters
@@ -74,7 +75,7 @@ def process_isometric_credits(
     download_type: str,
     prj_id_to_short_code: dict | None = None,
     registry_name: str = 'isometric',
-    prefix: str = 'ISO',
+    prefix: str = ISO_PREFIX,
     harmonize_beneficiary_info: bool = False,
 ) -> pd.DataFrame:
     """Process Isometric credits dataframe to conform to offsets-db schema.

--- a/offsets_db_data/registry.py
+++ b/offsets_db_data/registry.py
@@ -1,11 +1,19 @@
+ACR_PREFIX = 'ACR'
+ART_PREFIX = 'ART'
+CAR_PREFIX = 'CAR'
+CCB_PREFIX = 'CCB'
+GLD_PREFIX = 'GLD'
+ISO_PREFIX = 'ISO'
+VCS_PREFIX = 'VCS'
+
 REGISTRY_ABBR_MAP = {
-    'vcs': 'verra',
-    'car': 'climate-action-reserve',
-    'acr': 'american-carbon-registry',
-    'art': 'art-trees',
-    'gld': 'gold-standard',
-    'ccb': 'cercarbono',
-    'iso': 'isometric',
+    ACR_PREFIX.lower(): 'american-carbon-registry',
+    ART_PREFIX.lower(): 'art-trees',
+    CAR_PREFIX.lower(): 'climate-action-reserve',
+    CCB_PREFIX.lower(): 'cercarbono',
+    GLD_PREFIX.lower(): 'gold-standard',
+    ISO_PREFIX.lower(): 'isometric',
+    VCS_PREFIX.lower(): 'verra',
 }
 
 

--- a/offsets_db_data/vcs.py
+++ b/offsets_db_data/vcs.py
@@ -16,6 +16,7 @@ from offsets_db_data.credits import *  # noqa: F403
 from offsets_db_data.credits import harmonize_beneficiary_data
 from offsets_db_data.models import credit_without_id_schema, project_schema
 from offsets_db_data.projects import *  # noqa: F403
+from offsets_db_data.registry import VCS_PREFIX
 
 
 @pf.register_dataframe_method
@@ -176,7 +177,7 @@ def process_vcs_credits(
     *,
     download_type: str = 'transactions',
     registry_name: str = 'verra',
-    prefix: str = 'VCS',
+    prefix: str = VCS_PREFIX,
     arb: pd.DataFrame | None = None,
     harmonize_beneficiary_info: bool = False,
 ) -> pd.DataFrame:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@
     test-cov         = "pytest --ignore=tests/test_integration.py --cov=./offsets_db_data --cov-report=xml --cov-report=term-missing"
     test-integration = "pytest tests/test_integration.py"
     test-all         = "pytest --ignore=tests/test_integration.py && pytest tests/test_integration.py"
+    audit-protocols  = "python scripts/audit-protocols.py"
 
     # Documentation tasks
     docs-build = "sphinx-build docs docs/_build"

--- a/scripts/audit-protocols.py
+++ b/scripts/audit-protocols.py
@@ -1,0 +1,402 @@
+"""Audit mapping coverage for protocols and project types.
+
+Outputs a markdown report to stdout. Use --output to also write it to a file.
+
+Run with:
+    pixi run audit-protocols                                      # local test data
+    pixi run audit-protocols --data-dir s3://bucket/raw/2026-05-15  # S3 raw data
+    pixi run audit-protocols --output docs/unmapped-protocols.md  # also write to file
+"""
+
+import argparse
+import contextlib
+import io
+import json
+import sys
+from collections import Counter, defaultdict
+from datetime import date
+from pathlib import Path
+from typing import TypedDict
+
+import pandas as pd
+import upath
+
+from offsets_db_data.common import (
+    BERKELEY_PROJECT_TYPE_UPATH,
+    PROJECT_SCHEMA_UPATH,
+    load_inverted_protocol_mapping,
+    load_registry_project_column_mapping,
+    load_type_category_mapping,
+)
+from offsets_db_data.projects import (
+    infer_project_type,
+    map_project_type_to_display_name,
+    map_protocol,
+)
+from offsets_db_data.registry import GLD_PREFIX, VCS_PREFIX
+
+
+class RegistrySource(TypedDict):
+    name: str
+    path: upath.UPath
+    berkeley_prefix: str | None
+
+
+class ProtocolEntry(TypedDict):
+    protocol_id: str
+    count: int
+    registries: list[str]
+
+
+class ProtocolGaps(TypedDict):
+    n_projects: int
+    string_registries: dict[str, dict[str, int]]
+
+
+class ProjectTypeGaps(TypedDict):
+    n_berkeley_resolved: int
+    n_unknown: int
+    no_protocol: dict[str, int]
+    has_unassigned: dict[str, int]
+    has_protocol: list[ProtocolEntry]
+
+
+_DEFAULT_DATA_DIR = upath.UPath(Path(__file__).parent.parent / 'tests' / 'data')
+
+# Prefix prepended to the raw project_id when looking up Berkeley data keys.
+# Registries not listed here use the raw project_id directly.
+_BERKELEY_ID_PREFIXES: dict[str, str] = {
+    'gold-standard': GLD_PREFIX,
+    'verra': VCS_PREFIX,
+}
+
+
+def _build_registry_sources(data_dir: upath.UPath) -> list[RegistrySource]:
+    # Registry names are read from PROJECT_SCHEMA_UPATH (authoritative source).
+    # Each spec pairs the registry name with its expected projects.csv path and
+    # the optional Berkeley ID prefix used when looking up berkeley-project-types.json.
+    names = json.loads(PROJECT_SCHEMA_UPATH.read_text())['project_id'].keys()
+    return [
+        RegistrySource(
+            name=name,
+            path=data_dir / name / 'projects.csv',
+            berkeley_prefix=_BERKELEY_ID_PREFIXES.get(name),
+        )
+        for name in names
+    ]
+
+
+def _resolve_csv(csv_path: upath.UPath) -> upath.UPath | None:
+    if csv_path.exists():
+        return csv_path
+    gz_path = csv_path.parent / (csv_path.name + '.gz')
+    if gz_path.exists():
+        return gz_path
+    return None
+
+
+def _load_mapped_df(
+    registry_name: str, csv_path: upath.UPath, inverted_mapping: dict[str, list[str]]
+) -> pd.DataFrame | None:
+    resolved = _resolve_csv(csv_path)
+    if resolved is None:
+        sys.stderr.write(f'  {registry_name}: data file not found, skipping\n')
+        return None
+
+    col_mapping = load_registry_project_column_mapping(registry_name=registry_name)
+    id_col = col_mapping.get('project_id')
+    protocol_col = col_mapping.get('original_protocol')
+
+    if not protocol_col:
+        sys.stderr.write(f'  {registry_name}: no protocol column in mapping, skipping\n')
+        return None
+
+    raw_df = pd.read_csv(resolved, usecols=lambda c: c in {id_col, protocol_col})
+    if protocol_col not in raw_df.columns:
+        sys.stderr.write(f'  {registry_name}: column {protocol_col!r} absent from CSV, skipping\n')
+        return None
+
+    df = raw_df.rename(columns={id_col: 'project_id', protocol_col: 'original_protocol'})
+    with contextlib.redirect_stdout(io.StringIO()):
+        return map_protocol(df, inverted_protocol_mapping=inverted_mapping)
+
+
+def _gather_protocol_gaps(
+    registry_specs: list[RegistrySource],
+    inverted_mapping: dict[str, list[str]],
+) -> ProtocolGaps:
+    string_registries: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    n_projects = 0
+    for spec in registry_specs:
+        df = _load_mapped_df(spec['name'], spec['path'], inverted_mapping)
+        if df is None:
+            continue
+        for _, row in df[df['protocol_unassigned'].notna()].iterrows():
+            strings = [
+                s for s in row['protocol_unassigned'] if inverted_mapping.get(s) != ['unknown']
+            ]
+            if strings:
+                n_projects += 1
+                for s in strings:
+                    string_registries[s][spec['name']] += 1
+    return ProtocolGaps(n_projects=n_projects, string_registries=string_registries)
+
+
+def _gather_project_type_gaps(
+    registry_specs: list[RegistrySource],
+    inverted_mapping: dict[str, list[str]],
+) -> ProjectTypeGaps:
+    type_mapping = load_type_category_mapping()
+    try:
+        berkeley_overrides = json.loads(BERKELEY_PROJECT_TYPE_UPATH.read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        berkeley_overrides = {}
+
+    rows: list[dict] = []
+    for spec in registry_specs:
+        df = _load_mapped_df(spec['name'], spec['path'], inverted_mapping)
+        if df is None:
+            continue
+        with contextlib.redirect_stdout(io.StringIO()):
+            df = infer_project_type(df)
+        for _, row in df.iterrows():
+            raw_id = str(row['project_id'])
+            prefix = spec['berkeley_prefix']
+            rows.append(
+                {
+                    'registry': spec['name'],
+                    'project_id': raw_id,
+                    'berkeley_id': f'{prefix}{raw_id}' if prefix else raw_id,
+                    'protocol': row['protocol'],
+                    'protocol_unassigned': row['protocol_unassigned'],
+                    'project_type': row['project_type'],
+                }
+            )
+
+    if not rows:
+        return ProjectTypeGaps(
+            n_berkeley_resolved=0, n_unknown=0, no_protocol={}, has_unassigned={}, has_protocol=[]
+        )
+
+    df_all = pd.DataFrame(rows)
+    n_before = (df_all['project_type'] == 'unknown').sum()
+    df_all['project_type'] = (
+        df_all['berkeley_id'].map(berkeley_overrides).fillna(df_all['project_type'])
+    )
+    with contextlib.redirect_stdout(io.StringIO()):
+        df_types = map_project_type_to_display_name(
+            df_all[['project_id', 'project_type']].copy(), type_category_mapping=type_mapping
+        )
+    df_all['display_type'] = df_types['project_type']
+
+    unknown = df_all[df_all['display_type'] == 'Unknown']
+    n_after = len(unknown)
+    no_protocol = unknown[unknown['protocol'].isna() & unknown['protocol_unassigned'].isna()]
+    has_unassigned = unknown[unknown['protocol_unassigned'].notna()]
+    has_protocol = unknown[unknown['protocol'].notna() & unknown['protocol_unassigned'].isna()]
+
+    protocol_counts: Counter = Counter()
+    protocol_registries: dict[str, set[str]] = defaultdict(set)
+    for _, row in has_protocol.iterrows():
+        for pid in row['protocol']:
+            protocol_counts[pid] += 1
+            protocol_registries[pid].add(row['registry'])
+
+    return ProjectTypeGaps(
+        n_berkeley_resolved=int(n_before - n_after),
+        n_unknown=int(n_after),
+        no_protocol=dict(no_protocol.groupby('registry')['project_id'].count()),
+        has_unassigned=dict(has_unassigned.groupby('registry')['project_id'].count()),
+        has_protocol=[
+            ProtocolEntry(
+                protocol_id=pid,
+                count=count,
+                registries=sorted(protocol_registries[pid]),
+            )
+            for pid, count in protocol_counts.most_common()
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering
+# ---------------------------------------------------------------------------
+
+
+def build_report(protocol_gaps: ProtocolGaps, type_gaps: ProjectTypeGaps) -> str:
+    """
+    Render a markdown audit report from pre-computed gap data.
+
+    Parameters
+    ----------
+    protocol_gaps : ProtocolGaps
+        Count and per-registry breakdown of unrecognised protocol strings.
+    type_gaps : ProjectTypeGaps
+        Structured gap data for project type mapping.
+
+    Returns
+    -------
+    str
+        Markdown-formatted report ending with a trailing newline.
+    """
+
+    def _md_table(
+        headers: list[str], rows: list[list[object]], right_align: set[int] | None = None
+    ) -> str:
+        right_align = right_align or set()
+        sep = ['---:' if i in right_align else '---' for i in range(len(headers))]
+        lines = [
+            '| ' + ' | '.join(headers) + ' |',
+            '| ' + ' | '.join(sep) + ' |',
+        ]
+        for row in rows:
+            lines.append('| ' + ' | '.join(str(c) for c in row) + ' |')
+        return '\n'.join(lines)
+
+    out: list[str] = []
+
+    out += [
+        '<!-- Auto-generated by `pixi run audit-protocols`. Do not edit manually. -->',
+        '',
+        '# Unmapped Protocols',
+        '',
+        f'_Last updated: {date.today().isoformat()}_',
+        '',
+        '> **Protocol** is a normalized term representing the methodological framework governing projects'
+        ' on registries. Other terms this may be referred to as include _methodology_, _protocol_, and _standard_.',
+        '',
+        '---',
+        '',
+    ]
+
+    out += ['## Unmapped Protocols', '']
+    if not protocol_gaps['string_registries']:
+        out.append('✓ All protocol strings are mapped.')
+    else:
+        out.append(f'{protocol_gaps["n_projects"]} project(s) have unrecognised protocol strings.')
+        out.append('')
+        table_rows = [
+            [f'`{s}`', sum(rc.values()), ', '.join(f'{r} ({c})' for r, c in sorted(rc.items()))]
+            for s, rc in sorted(protocol_gaps['string_registries'].items())
+        ]
+        out.append(_md_table(['String', 'Projects', 'Registries'], table_rows, right_align={1}))
+
+    out += ['', '---', '']
+
+    n = type_gaps['n_unknown']
+    n_unassigned = sum(type_gaps['has_unassigned'].values()) if type_gaps['has_unassigned'] else 0
+    unassigned_note = (
+        f' Resolving the protocol strings in the [Unmapped Protocols](#unmapped-protocols)'
+        f' section above will also fix {n_unassigned} of these.'
+        if n_unassigned
+        else ''
+    )
+    out += [
+        '## Unmapped Project Types',
+        '',
+        f'Berkeley overrides resolved {type_gaps["n_berkeley_resolved"]} project(s); {n} still unknown.{unassigned_note}',
+        '',
+    ]
+
+    if n == 0:
+        out.append('✓ All projects have a recognised project type.')
+    else:
+        if type_gaps['no_protocol']:
+            total = sum(type_gaps['no_protocol'].values())
+            out += [
+                f'### No protocol in raw data ({total} projects)',
+                '',
+                'The raw registry data contains no protocol field for these projects, there is nothing to map.',
+                '',
+            ]
+            out.append(
+                _md_table(
+                    ['Registry', 'Projects'],
+                    [[r, c] for r, c in sorted(type_gaps['no_protocol'].items())],
+                    right_align={1},
+                )
+            )
+            out.append('')
+
+        if type_gaps['has_protocol']:
+            n_has_protocol = sum(e['count'] for e in type_gaps['has_protocol'])
+            out += [
+                f'### Protocols mapped with no project types ({n_has_protocol} projects)',
+                '',
+                'The protocol string is mapped to a known protocol ID, but `infer_project_type()` has no rule'
+                ' for that protocol ID. Add a rule to `offsets_db_data/projects.py` to resolve them.',
+                '',
+            ]
+            out.append(
+                _md_table(
+                    ['Protocol', 'Projects', 'Registries'],
+                    [
+                        [f'`{e["protocol_id"]}`', e['count'], ', '.join(e['registries'])]
+                        for e in type_gaps['has_protocol']
+                    ],
+                    right_align={1},
+                )
+            )
+            out.append('')
+
+    return '\n'.join(out) + '\n'
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description='Audit mapping coverage for protocols and project types.'
+    )
+    parser.add_argument(
+        '--data-dir',
+        type=upath.UPath,
+        default=_DEFAULT_DATA_DIR,
+        metavar='PATH',
+        help=f'Path to registry data directory, local or S3 URI (default: {_DEFAULT_DATA_DIR})',
+    )
+    parser.add_argument(
+        '--output',
+        type=Path,
+        default=None,
+        metavar='PATH',
+        help='Also write the report to this file',
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    data_dir = args.data_dir
+
+    if not data_dir.exists():
+        sys.stderr.write(f'ERROR: data directory not found: {data_dir}\n')
+        if data_dir == upath.UPath(_DEFAULT_DATA_DIR):
+            sys.stderr.write(
+                'Run the test suite first to populate sample data, or pass --data-dir.\n'
+            )
+        sys.exit(2)
+
+    inverted_mapping = load_inverted_protocol_mapping()
+    specs = _build_registry_sources(data_dir)
+
+    protocol_gaps = _gather_protocol_gaps(specs, inverted_mapping)
+    type_gaps = _gather_project_type_gaps(specs, inverted_mapping)
+    n_types = type_gaps['n_unknown']
+
+    report = build_report(protocol_gaps, type_gaps)
+    print(report, end='')
+
+    if args.output:
+        args.output.write_text(report)
+        sys.stderr.write(f'Report written to {args.output}\n')
+
+    total = protocol_gaps['n_projects'] + n_types
+    if total > 0:
+        sys.stderr.write(
+            f'\n{total} gap(s) found: {protocol_gaps["n_projects"]} unmapped protocol string(s),'
+            f' {n_types} unmapped project type(s).\n'
+        )
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_audit_protocols.py
+++ b/tests/test_audit_protocols.py
@@ -1,0 +1,261 @@
+"""Unit tests for scripts/audit-protocols.py."""
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import upath
+
+# Import the audit script directly (it lives outside the package).
+# Using importlib to avoid relying on sys.path ordering.
+_AUDIT_PY = Path(__file__).parent.parent / 'scripts' / 'audit-protocols.py'
+_spec = importlib.util.spec_from_file_location('audit', _AUDIT_PY)
+_audit = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_audit)
+
+_DATA_DIR = Path(__file__).parent / 'data'
+_KNOWN_UNKNOWN_SENTINELS = (
+    'Not defined',
+    'Other',
+    'Not provided',
+    'Not Provided',
+    'Methodology Under Development',
+)
+
+_EMPTY_PROTOCOL_GAPS = _audit.ProtocolGaps(n_projects=0, string_registries={})
+_EMPTY_TYPE_GAPS = _audit.ProjectTypeGaps(
+    n_berkeley_resolved=0,
+    n_unknown=0,
+    no_protocol={},
+    has_unassigned={},
+    has_protocol=[],
+)
+
+
+# ── build_report ──────────────────────────────────────────────────────────────
+
+
+def test_build_report_starts_with_html_comment():
+    """Report starts with the auto-generated HTML comment, followed by the H1."""
+    report = _audit.build_report(_EMPTY_PROTOCOL_GAPS, _EMPTY_TYPE_GAPS)
+    assert report.startswith('<!-- Auto-generated')
+    assert '# Unmapped Protocols' in report
+
+
+def test_build_report_no_gaps_shows_all_clear():
+    """All-clear messages appear when there are no protocol or type gaps."""
+    report = _audit.build_report(_EMPTY_PROTOCOL_GAPS, _EMPTY_TYPE_GAPS)
+    assert '✓ All protocol strings are mapped.' in report
+    assert '✓ All projects have a recognised project type.' in report
+
+
+def test_build_report_protocol_gap_appears_in_table():
+    """Unrecognised protocol strings are listed in the table with correct counts."""
+    protocol_gaps = _audit.ProtocolGaps(n_projects=3, string_registries={'VM0999': {'verra': 3}})
+    report = _audit.build_report(protocol_gaps, _EMPTY_TYPE_GAPS)
+    assert '3 project(s)' in report
+    assert '`VM0999`' in report
+    assert '| 3 |' in report
+
+
+def test_build_report_type_gap_sections():
+    """Type gap subsections appear when no_protocol and has_protocol are populated."""
+    type_gaps = _audit.ProjectTypeGaps(
+        n_berkeley_resolved=10,
+        n_unknown=5,
+        no_protocol={'gold-standard': 5},
+        has_unassigned={},
+        has_protocol=[
+            _audit.ProtocolEntry(
+                protocol_id='ams-i-f', count=3, registries=['verra', 'gold-standard']
+            )
+        ],
+    )
+    report = _audit.build_report(_EMPTY_PROTOCOL_GAPS, type_gaps)
+    assert '### No protocol in raw data' in report
+    assert 'gold-standard' in report
+    assert '### Protocols mapped with no project types' in report
+    assert '`ams-i-f`' in report
+
+
+def test_build_report_unassigned_note_cross_references_protocol_section():
+    """Berkeley summary line links to the Unmapped Protocols section when has_unassigned."""
+    type_gaps = _audit.ProjectTypeGaps(
+        n_berkeley_resolved=0,
+        n_unknown=5,
+        no_protocol={},
+        has_unassigned={'verra': 5},
+        has_protocol=[],
+    )
+    report = _audit.build_report(_EMPTY_PROTOCOL_GAPS, type_gaps)
+    assert '[Unmapped Protocols](#unmapped-protocols)' in report
+    assert '5 of these' in report
+
+
+def test_build_report_ends_with_newline():
+    """Report string always ends with a trailing newline."""
+    report = _audit.build_report(_EMPTY_PROTOCOL_GAPS, _EMPTY_TYPE_GAPS)
+    assert report.endswith('\n')
+
+
+# ── _BERKELEY_ID_PREFIXES ────────────────────────────────────────────────────
+
+
+def test_berkeley_prefix_assigned_to_bare_id_registries():
+    """Verra and gold-standard get a Berkeley prefix; other registries get None."""
+    from offsets_db_data.registry import GLD_PREFIX, VCS_PREFIX
+
+    sources = _audit._build_registry_sources(upath.UPath(_DATA_DIR))
+    by_name = {s['name']: s['berkeley_prefix'] for s in sources}
+    assert by_name.get('verra') == VCS_PREFIX
+    assert by_name.get('gold-standard') == GLD_PREFIX
+    assert by_name.get('american-carbon-registry') is None
+    assert by_name.get('climate-action-reserve') is None
+
+
+def test_berkeley_prefix_registries_have_bare_project_ids(registry_specs, inverted_mapping):
+    """Raw project IDs for prefixed registries don't already start with the prefix.
+
+    If a registry's raw CSV IDs already carry the prefix (e.g. 'ACR586'), adding it
+    again in _BERKELEY_ID_PREFIXES would produce double-prefixed keys ('ACRACR586')
+    that never match the Berkeley data, silently breaking project-type resolution.
+    """
+    for spec in registry_specs:
+        if spec['berkeley_prefix'] is None:
+            continue
+        df = _audit._load_mapped_df(spec['name'], spec['path'], inverted_mapping)
+        if df is None:
+            continue
+        prefix = spec['berkeley_prefix']
+        assert not any(str(pid).startswith(prefix) for pid in df['project_id']), (
+            f'{spec["name"]} raw IDs already start with {prefix!r} — '
+            f'remove it from _BERKELEY_ID_PREFIXES'
+        )
+
+
+# ── _gather_protocol_gaps ─────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope='module')
+def inverted_mapping():
+    from offsets_db_data.common import load_inverted_protocol_mapping
+
+    return load_inverted_protocol_mapping()
+
+
+@pytest.fixture(scope='module')
+def registry_specs():
+    import upath
+
+    return _audit._build_registry_sources(upath.UPath(_DATA_DIR))
+
+
+@pytest.fixture(scope='module')
+def protocol_gaps(registry_specs, inverted_mapping):
+    return _audit._gather_protocol_gaps(registry_specs, inverted_mapping)
+
+
+def test_protocol_gaps_finds_gaps(protocol_gaps):
+    """At least one unrecognised protocol string exists in the test data."""
+    assert protocol_gaps['n_projects'] > 0
+    assert len(protocol_gaps['string_registries']) > 0
+
+
+def test_protocol_gaps_filters_unknown_sentinels(protocol_gaps):
+    """Known-unknown sentinel strings are excluded from the gap report."""
+    for sentinel in _KNOWN_UNKNOWN_SENTINELS:
+        assert sentinel not in protocol_gaps['string_registries'], (
+            f'{sentinel!r} should be filtered by the unknown sentinel'
+        )
+
+
+def test_protocol_gaps_counts_are_positive(protocol_gaps):
+    """Every registry count in the gap report is greater than zero."""
+    for s, reg_counts in protocol_gaps['string_registries'].items():
+        assert all(c > 0 for c in reg_counts.values()), f'Zero count for {s!r}'
+
+
+# ── _gather_project_type_gaps ─────────────────────────────────────────────────
+
+
+@pytest.fixture(scope='module')
+def type_gaps(registry_specs, inverted_mapping):
+    return _audit._gather_project_type_gaps(registry_specs, inverted_mapping)
+
+
+def test_project_type_gaps_has_unknowns(type_gaps):
+    """Some projects remain unresolved after Berkeley overrides are applied."""
+    assert type_gaps['n_unknown'] > 0
+
+
+def test_project_type_gaps_berkeley_resolved_some(type_gaps):
+    """Berkeley overrides resolve at least one previously unknown project type."""
+    assert type_gaps['n_berkeley_resolved'] > 0
+
+
+def test_project_type_gaps_has_protocol_entries(type_gaps):
+    """has_protocol contains valid ProtocolEntry dicts."""
+    assert len(type_gaps['has_protocol']) > 0
+    for entry in type_gaps['has_protocol']:
+        assert isinstance(entry['protocol_id'], str)
+        assert entry['count'] > 0
+        assert isinstance(entry['registries'], list) and len(entry['registries']) > 0
+
+
+def test_project_type_gaps_proto_counts_sorted_descending(type_gaps):
+    """has_protocol entries are sorted from highest to lowest project count."""
+    counts = [entry['count'] for entry in type_gaps['has_protocol']]
+    assert counts == sorted(counts, reverse=True)
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+
+def test_cli_exits_nonzero_on_gaps():
+    """Script exits with code 1 when gaps are found in the test data."""
+    result = subprocess.run([sys.executable, str(_AUDIT_PY)], capture_output=True, text=True)
+    assert result.returncode == 1
+
+
+def test_cli_stdout_is_markdown():
+    """Stdout is a valid markdown report with the expected top-level headings."""
+    result = subprocess.run([sys.executable, str(_AUDIT_PY)], capture_output=True, text=True)
+    assert result.stdout.startswith('<!-- Auto-generated')
+    assert '# Unmapped Protocols' in result.stdout
+    assert '## Unmapped Protocols' in result.stdout
+    assert '## Unmapped Project Types' in result.stdout
+
+
+def test_cli_output_flag_writes_file(tmp_path):
+    """--output writes the report to the specified file."""
+    out_file = tmp_path / 'report.md'
+    subprocess.run(
+        [sys.executable, str(_AUDIT_PY), '--output', str(out_file)],
+        capture_output=True,
+        text=True,
+    )
+    assert out_file.exists()
+    assert '# Unmapped Protocols' in out_file.read_text()
+
+
+def test_cli_stdout_matches_file(tmp_path):
+    """stdout and the --output file contain identical content."""
+    out_file = tmp_path / 'report.md'
+    result = subprocess.run(
+        [sys.executable, str(_AUDIT_PY), '--output', str(out_file)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout == out_file.read_text()
+
+
+def test_cli_invalid_data_dir_exits_with_code_2(tmp_path):
+    """Passing a nonexistent --data-dir exits with code 2."""
+    result = subprocess.run(
+        [sys.executable, str(_AUDIT_PY), '--data-dir', str(tmp_path / 'nonexistent')],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2


### PR DESCRIPTION
https://github.com/carbonplan/offsets-db-data/issues/170

PR includes a new script to provide a report of mapping coverage for protocols and project types. The PR also updates the CI config to run and upload the report to the docs.

The script can be ran as a command with:

`pixi run audit-protocols` which defaults to using the local test data

`pixi run audit-protocols --data-dir s3://bucket/raw/2026-05-15` to point to a different directory or use the S3 bucket.

`pixi run audit-protocols --output docs/unmapped-protocols.md` to output the report.

The output is formatted in markdown so it can be linked to the docs, the markdown's table formatting also makes reading the protocols in the report a lot easier.


<img width="2889" height="2148" alt="Screenshot 2026-06-12 at 10-46-01 Unmapped Protocols — offsets-db-data" src="https://github.com/user-attachments/assets/c23cfd2b-85d3-43a9-9b0c-4aeaf86ab068" />
